### PR TITLE
fix(SpecialThanks): change some classes to fix content in mobile

### DIFF
--- a/adventofcss/src/routes/SpecialThanks.svelte
+++ b/adventofcss/src/routes/SpecialThanks.svelte
@@ -2,8 +2,8 @@
 	import { Constants } from '$lib/helpers/Constants';
 </script>
 
-<div class="py-16 text-center layout-grid">
-	<div class="col-start-4 col-span-6">
+<div class="py-16 text-center grid grid-cols-1 lg:grid-cols-12 gap-x-5 px-10">
+	<div class="lg:col-start-4 lg:col-span-6">
 		<div class="flex items-center gap-x-5 justify-center mb-3">
 			<div>
 				<img


### PR DESCRIPTION
**📸 Screenshots**
<img width="500" alt="Captura de pantalla 2023-11-24 a la(s) 6 30 14 p m" src="https://github.com/ahaywood/adventof-2023/assets/11619953/b6b94499-d5cc-4475-9f91-7dd6cc652713">
<img width="503" alt="Captura de pantalla 2023-11-24 a la(s) 6 30 28 p m" src="https://github.com/ahaywood/adventof-2023/assets/11619953/87f345e4-819e-4e97-9b8e-309e69407e1a">

**Current behavior:**
Section SpecialThanks is bigger than screen width



